### PR TITLE
Retry open if fail

### DIFF
--- a/META.json
+++ b/META.json
@@ -4,13 +4,13 @@
       "Miroslav Tynovsky <tynovsky@avast.com>"
    ],
    "dynamic_config" : 0,
-   "generated_by" : "Minilla/v3.0.12, CPAN::Meta::Converter version 2.150005",
+   "generated_by" : "Minilla/v3.0.12, CPAN::Meta::Converter version 2.150010",
    "license" : [
       "perl_5"
    ],
    "meta-spec" : {
       "url" : "http://search.cpan.org/perldoc?CPAN::Meta::Spec",
-      "version" : "2"
+      "version" : 2
    },
    "name" : "Stor",
    "no_index" : {
@@ -52,6 +52,7 @@
             "Path::Tiny" : "0",
             "Safe::Isa" : "0",
             "Syntax::Keyword::Try" : "0",
+            "Try::Tiny::Retry" : "0",
             "failures" : "0",
             "perl" : "5.022"
          }
@@ -72,6 +73,9 @@
          "url" : "git://git.int.avast.com/perl-modules/Stor.git"
       }
    },
-   "version" : "0.4.0",
-   "x_serialization_backend" : "JSON::PP version 2.27400"
+   "version" : "0.4.1",
+   "x_contributors" : [
+      "Jan Seidl <seidl@avast.com>"
+   ],
+   "x_serialization_backend" : "JSON::PP version 2.94"
 }

--- a/cpanfile
+++ b/cpanfile
@@ -8,6 +8,7 @@ requires 'Cpanel::JSON::XS';
 requires 'Net::Statsite::Client';
 requires 'failures';
 requires 'Safe::Isa';
+requires 'Try::Tiny::Retry';
 
 on 'test' => sub {
     requires 'Test::More', '0.98';

--- a/lib/Stor.pm
+++ b/lib/Stor.pm
@@ -1,7 +1,7 @@
 package Stor;
 use v5.20;
 
-our $VERSION = '0.4.0';
+our $VERSION = '0.4.1';
 
 use Mojo::Base -base;
 use Syntax::Keyword::Try;
@@ -12,6 +12,7 @@ use List::MoreUtils qw(first_index);
 use Digest::SHA qw(sha256_hex);
 use failures qw(stor);
 use Safe::Isa;
+use Try::Tiny::Retry;
 
 use feature 'signatures';
 no warnings 'experimental::signatures';
@@ -194,7 +195,13 @@ sub _sha_to_filepath($self, $sha) {
 
 sub _stream_found_file($self, $c, $path) {
 
-    my $fh = $path->openr_raw();
+    my $fh;
+    retry {
+        $fh = $path->openr_raw();
+    }
+    catch {
+        die $_;
+    };
 
     my $drain; $drain = sub {
         my ($c) = @_;


### PR DESCRIPTION
Stor sometimes return 404 on existing file:

```
curl -v prg51-013.srv.int.avast.com:31355/BFD8849246B56659ABE01394A5C20E87064BBCAEB31D112B6B27F2D606B23F9A
--
*   Trying 10.1.55.227...
* TCP_NODELAY set
* Connected to prg51-013.srv.int.avast.com (10.1.55.227) port 31355 (#0)
> GET /BFD8849246B56659ABE01394A5C20E87064BBCAEB31D112B6B27F2D606B23F9A HTTP/1.1
> Host: prg51-013.srv.int.avast.com:31355
> User-Agent: curl/7.53.1
> Accept: */*
>
< HTTP/1.1 404 Not Found
< Content-Length: 28672
< Date: Thu, 12 Oct 2017 10:07:38 GMT
< Server: Mojolicious (Perl)
< Content-Type: text/html;charset=UTF-8
<
Error open (<:raw) on '/nfs/prg24-008.srv.int.avast.com/data/storage/Samples/BF/D8/84/BFD8849246B56659ABE01394A5C20E87064BBCAEB31D112B6B27F2D606B23F9A.dat': Input/output error at /usr/local/lib/perl5/site_perl/5.24.1/Stor.pm line 197.
* transfer closed with 28437 bytes remaining to read
* stopped the pause stream!
* Closing connection 0
curl: (18) transfer closed with 28437 bytes remaining to read
```

probably some problem with NFS mount... Retry should be this fix...