### PR TITLE
fix bad status

### DIFF
--- a/META.json
+++ b/META.json
@@ -68,13 +68,19 @@
    },
    "release_status" : "unstable",
    "resources" : {
+      "bugtracker" : {
+         "web" : "https://github.com/avast/Stor/issues"
+      },
+      "homepage" : "https://github.com/avast/Stor",
       "repository" : {
          "type" : "git",
-         "url" : "git://git.int.avast.com/perl-modules/Stor.git"
+         "url" : "git://github.com/avast/Stor.git",
+         "web" : "https://github.com/avast/Stor"
       }
    },
-   "version" : "0.4.1",
+   "version" : "0.4.2",
    "x_contributors" : [
+      "Jan Seidl <janseidl@volny.cz>",
       "Jan Seidl <seidl@avast.com>"
    ],
    "x_serialization_backend" : "JSON::PP version 2.94"

--- a/lib/Stor.pm
+++ b/lib/Stor.pm
@@ -1,7 +1,7 @@
 package Stor;
 use v5.20;
 
-our $VERSION = '0.4.1';
+our $VERSION = '0.4.2';
 
 use Mojo::Base -base;
 use Syntax::Keyword::Try;
@@ -10,7 +10,7 @@ use List::Util qw(shuffle min max);
 use Mojo::Util qw(secure_compare);
 use List::MoreUtils qw(first_index);
 use Digest::SHA qw(sha256_hex);
-use failures qw(stor);
+use failures qw(stor stor::filenotfound);
 use Safe::Isa;
 use Try::Tiny::Retry;
 
@@ -44,13 +44,13 @@ sub status ($self, $c) {
 sub get ($self, $c) {
     my $sha = $c->param('sha');
     try {
-        failure::stor->throw({
+        failure::stor::filenotfound->throw({
             msg     => "Given hash '$sha' isn't SHA256",
             payload => { statsite_key => 'error.get.malformed_sha.count' },
         }) if $sha !~ /^[A-Fa-f0-9]{64}$/;
 
         my $paths = $self->_lookup($sha);
-        failure::stor->throw({
+        failure::stor::filenotfound->throw({
             msg     => "File '$sha' not found",
             payload => { statsite_key => 'error.get.not_found.count' },
         }) if !@$paths;
@@ -62,13 +62,13 @@ sub get ($self, $c) {
     }
     catch {
         $c->app->log->debug("$@");
-        if ($@->$_isa('failure::stor')) {
+        if ($@->$_isa('failure::stor::filenotfound')) {
             $self->statsite->increment($@->payload->{statsite_key});
+            return $c->render(status => 404, text => "$@");
         }
-        else {
-            $self->statsite->increment('error.get.unknown.count');
-        }
-        $c->render(status => 404, text => "$@");
+
+        $self->statsite->increment('error.get.unknown.count');
+        return $c->render(status => 500, text => "$@");
     }
 }
 

--- a/lib/Stor.pm
+++ b/lib/Stor.pm
@@ -63,12 +63,19 @@ sub get ($self, $c) {
     catch {
         $c->app->log->debug("$@");
         if ($@->$_isa('failure::stor::filenotfound')) {
-            $self->statsite->increment($@->payload->{statsite_key});
-            return $c->render(status => 404, text => "$@");
+            $c->render(status => 404, text => "$@");
         }
-
-        $self->statsite->increment('error.get.unknown.count');
-        return $c->render(status => 500, text => "$@");
+        else {
+            $c->render(status => 500, text => "$@");
+        }
+    }
+    finally {
+        if ($@->$_isa('failure::stor')) {
+            $self->statsite->increment($@->payload->{statsite_key});
+        }
+        else {
+            $self->statsite->increment('error.get.unknown.count');
+        }
     }
 }
 


### PR DESCRIPTION
again:
```
Error open (<:raw) on '/nfs/prg24-002.srv.int.avast.com/data/storage/Samples/74/AA/CE/74AACEE48443C5CFB687A7BE595FF74B43EC5D2C248DD477BE88A0624D5D5435.dat': Input/output error at /usr/local/lib/perl5/site_perl/5.24.2/Stor.pm line 200.
```

throw exception was returned 404 (this wasn't correct in all cases)