### PR TITLE
time and size metrics

### DIFF
--- a/lib/Stor.pm
+++ b/lib/Stor.pm
@@ -44,7 +44,6 @@ sub status ($self, $c) {
 
 sub get ($self, $c) {
     my $sha = $c->param('sha');
-    my $tm_start = time;
     try {
         failure::stor::filenotfound->throw({
             msg     => "Given hash '$sha' isn't SHA256",
@@ -58,12 +57,9 @@ sub get ($self, $c) {
         }) if !@$paths;
 
         my $path = $paths->[0];
-        my $size = -s $path;
-        $c->res->headers->content_length($size);
+        $c->res->headers->content_length(-s $size);
         $self->_stream_found_file($c, $path);
         $self->statsite->increment('success.get.ok.count');
-        $self->statsite->timing('success.get.ok.time', (time - $tm_start) / 1000);
-        $self->statsite->update('success.get.ok.size', $size);
     }
     catch {
         $c->app->log->debug("$@");
@@ -212,18 +208,21 @@ sub _sha_to_filepath($self, $sha) {
 
 
 sub _stream_found_file($self, $c, $path) {
-
+    my $tm_start = time;
     my $fh = $path->openr_raw();
     my $drain; $drain = sub {
         my ($c) = @_;
 
         my $chunk;
-        if (read($fh, $chunk, 1024 * 1024) == 0) {
+        my $size = read($fh, $chunk, 1024 * 1024);
+        if ($size == 0) {
             close($fh);
             $drain = undef;
         }
 
         $c->write($chunk, $drain)
+        $self->statsite->update('success.get.ok.size', $size);
+        $self->statsite->timing('success.get.ok.time', (time - $tm_start) / 1000);
     };
     $c->$drain;
 }

--- a/lib/Stor.pm
+++ b/lib/Stor.pm
@@ -57,7 +57,7 @@ sub get ($self, $c) {
         }) if !@$paths;
 
         my $path = $paths->[0];
-        $c->res->headers->content_length(-s $size);
+        $c->res->headers->content_length(-s $path);
         $self->_stream_found_file($c, $path);
         $self->statsite->increment('success.get.ok.count');
     }
@@ -220,7 +220,7 @@ sub _stream_found_file($self, $c, $path) {
             $drain = undef;
         }
 
-        $c->write($chunk, $drain)
+        $c->write($chunk, $drain);
         $self->statsite->update('success.get.ok.size', $size);
         $self->statsite->timing('success.get.ok.time', (time - $tm_start) / 1000);
     };


### PR DESCRIPTION
Because get of file is asynchronous, is need mesaure time in drain function. Size must be mesaure in same place, because head use same function (without drain).