### PR TITLE
Bugfix when zero-sized chunk is sent form hcp

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Perl extension Stor
 
 
+0.10.1
+    - Bugfix when zero-sized chunk is sent form hcp
 0.10.0
     - Properly streaming files form hcp storage
 0.9.0

--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Perl extension Stor
 
 
+0.10.2
+    - Timings to statsite is now in miliseconds
 0.10.1
     - Bugfix when zero-sized chunk is sent form hcp
 0.10.0

--- a/META.json
+++ b/META.json
@@ -4,13 +4,13 @@
       "Miroslav Tynovsky <tynovsky@avast.com>"
    ],
    "dynamic_config" : 0,
-   "generated_by" : "Minilla/v3.0.12, CPAN::Meta::Converter version 2.150010",
+   "generated_by" : "Minilla/v3.0.17, CPAN::Meta::Converter version 2.150005",
    "license" : [
       "perl_5"
    ],
    "meta-spec" : {
       "url" : "http://search.cpan.org/perldoc?CPAN::Meta::Spec",
-      "version" : 2
+      "version" : "2"
    },
    "name" : "Stor",
    "no_index" : {
@@ -84,7 +84,7 @@
          "web" : "https://github.com/avast/Stor"
       }
    },
-   "version" : "0.10.0",
+   "version" : "0.10.1",
    "x_contributors" : [
       "Jan Seidl <janseidl@volny.cz>",
       "Jan Seidl <seidl@avast.com>",
@@ -93,5 +93,5 @@
       "Tomas Pavlik <savlik5@gmail.com>",
       "Tomas Pavlik <tomas.pavlik@avast.com>"
    ],
-   "x_serialization_backend" : "JSON::PP version 2.94"
+   "x_serialization_backend" : "JSON::PP version 2.27300_01"
 }

--- a/META.json
+++ b/META.json
@@ -84,7 +84,7 @@
          "web" : "https://github.com/avast/Stor"
       }
    },
-   "version" : "0.10.1",
+   "version" : "0.10.2",
    "x_contributors" : [
       "Jan Seidl <janseidl@volny.cz>",
       "Jan Seidl <seidl@avast.com>",

--- a/lib/Stor.pm
+++ b/lib/Stor.pm
@@ -1,7 +1,7 @@
 package Stor;
 use v5.20;
 
-our $VERSION = '0.10.1';
+our $VERSION = '0.10.2';
 
 use Mojo::Base -base, -signatures;
 use Syntax::Keyword::Try;
@@ -60,7 +60,7 @@ sub status ($self, $c) {
 sub get_from_old_storages ($self, $c, $sha) {
     my $tm_cache = time;
     my $path     = $c->chi->get($sha);
-    $self->statsite->timing('cache.time', (time - $tm_cache) / 1000);
+    $self->statsite->timing('cache.time', (time - $tm_cache) * 1000);
     if ($path) {
         $self->statsite->increment('cache.hit');
     }
@@ -129,7 +129,7 @@ sub get_from_hcp ($self, $c, $sha) {
         sub {
             $self->statsite->increment('success.get.ok_hcp.count');
             $self->statsite->update('success.get.ok_hcp.size', $size);
-            $self->statsite->timing('success.get.ok_hcp.time', (time - $time) / 1000);
+            $self->statsite->timing('success.get.ok_hcp.time', (time - $time) * 1000);
         }
     );
 
@@ -281,7 +281,7 @@ sub _lookup ($self, $sha, $return_all_paths = '') {
     my $tm_start = time;
 
     scope_guard {
-        $self->statsite->timing('lookup.time', (time - $tm_start) / 1000);
+        $self->statsite->timing('lookup.time', (time - $tm_start) * 1000);
         $self->statsite->increment("lookup.attempt.$attempt.count");
     };
 
@@ -324,7 +324,7 @@ sub _stream_found_file($self, $c, $path) {
 
         $c->write($chunk, $drain);
         $self->statsite->update('success.get.ok_old.size', $size);
-        $self->statsite->timing('success.get.ok_old.time', (time - $tm_chunk) / 1000);
+        $self->statsite->timing('success.get.ok_old.time', (time - $tm_chunk) * 1000);
     };
     $c->$drain;
 }

--- a/lib/Stor.pm
+++ b/lib/Stor.pm
@@ -1,7 +1,7 @@
 package Stor;
 use v5.20;
 
-our $VERSION = '0.10.0';
+our $VERSION = '0.10.1';
 
 use Mojo::Base -base, -signatures;
 use Syntax::Keyword::Try;
@@ -116,7 +116,9 @@ sub get_from_hcp ($self, $c, $sha) {
     $tx->res->content->on(
         read => sub {
             my (undef, $chunk) = @_;
-            $c->write($chunk);
+            if ($chunk) {
+                $c->write($chunk);
+            }
         }
     );
 


### PR DESCRIPTION
When resending messages from HCP; if one chunk is zero-length (which can happen), then Mojo will close the connection. (https://mojolicious.org/perldoc/Mojo/Content#write "You can write an empty chunk of data at any time to end the stream.")