### PR TITLE
Fix streaming bigger files from hcp

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for Perl extension Stor
 
 
 {{$NEXT}}
+    - S3bug: Bigger samples then 503MB wasn't downloaded, becuase default user agent limit. Now is limit unlimited (because file is streamed)
+1.1.2
     - Recurring cleanup task for old mojo temp files
 1.1.0
     - Added logging

--- a/Changes
+++ b/Changes
@@ -4,7 +4,7 @@ Revision history for Perl extension Stor
 {{$NEXT}}
     - Recurring cleanup task for old mojo temp files
 1.1.0
-	- Added logging
+    - Added logging
 1.0.0 2018-05-11T09:08:33Z
     - fix & improve documentation
     - configuration changes:

--- a/META.json
+++ b/META.json
@@ -87,7 +87,7 @@
          "web" : "https://github.com/avast/Stor"
       }
    },
-   "version" : "1.1.2",
+   "version" : "1.1.3",
    "x_contributors" : [
       "Jan Seidl <janseidl@volny.cz>",
       "Jan Seidl <seidl@avast.com>",

--- a/META.json
+++ b/META.json
@@ -4,13 +4,13 @@
       "Miroslav Tynovsky <tynovsky@avast.com>"
    ],
    "dynamic_config" : 0,
-   "generated_by" : "Minilla/v3.0.17, CPAN::Meta::Converter version 2.150005",
+   "generated_by" : "Minilla/v3.0.12, CPAN::Meta::Converter version 2.150010",
    "license" : [
       "perl_5"
    ],
    "meta-spec" : {
       "url" : "http://search.cpan.org/perldoc?CPAN::Meta::Spec",
-      "version" : "2"
+      "version" : 2
    },
    "name" : "Stor",
    "no_index" : {
@@ -96,5 +96,5 @@
       "Tomas Pavlik <savlik5@gmail.com>",
       "Tomas Pavlik <tomas.pavlik@avast.com>"
    ],
-   "x_serialization_backend" : "JSON::PP version 2.27300_01"
+   "x_serialization_backend" : "JSON::PP version 2.94"
 }

--- a/lib/Stor.pm
+++ b/lib/Stor.pm
@@ -1,7 +1,7 @@
 package Stor;
 use v5.20;
 
-our $VERSION = '1.1.2';
+our $VERSION = '1.1.3';
 
 use Mojo::Base -base, -signatures;
 use Syntax::Keyword::Try;
@@ -108,6 +108,7 @@ sub get_from_s3 ($self, $c, $sha) {
     )->http_request;
 
     # build Mojo request inside transaction for proper streaming
+    $c->app->ua->max_response_size(0);
     my $tx = $c->app->ua->build_tx(GET => $http_request->uri->as_string);
     for my $header_key ('authorization', 'date') {
         $tx->req->headers->header($header_key => $http_request->headers->header($header_key));


### PR DESCRIPTION
s3bug: bigger samples then 503MB wasn't downloaded, becuase default user agent limit. Now is limit unlimited (because file is streamed).